### PR TITLE
Add sigmoid.social

### DIFF
--- a/diffusion-output-list
+++ b/diffusion-output-list
@@ -1,1 +1,2 @@
 midjourney.com
+sigmoid.social


### PR DESCRIPTION
I'd like to 
- [x] add
- [ ] remove
these domain(s) or URL(s) to the diffusion output list.

Criteria:

- [x] This site includes diffusion output on a public-facing page.
- [x] These images hypothetically replace human artworks. (That is, they are not
  examples of diffusion output for the purpose of technical discussion.)

If either criterion are not fulfilled, your domain(s) or URL(s) cannot be on the
list.

Please describe below why these criteria are or are not fulfilled.

> The website is dedicated to AI content, and the logo image on /about is AI generated.