### PR TITLE
added old reddit alternative

### DIFF
--- a/diffusion-output-list
+++ b/diffusion-output-list
@@ -1,3 +1,4 @@
 midjourney.com
 sigmoid.social
 reddit.com/r/aiwallpapers/
+old.reddit.com/r/aiwallpapers/


### PR DESCRIPTION
I'd like to 
- [x] add
- [ ] remove
these domain(s) or URL(s) to the diffusion output list.

Criteria:

- [x] This site includes diffusion output on a public-facing page.
- [x] These images hypothetically replace human artworks. (That is, they are not
  examples of diffusion output for the purpose of technical discussion.)

If either criterion are not fulfilled, your domain(s) or URL(s) cannot be on the
list.
