### PR TITLE
Add Astral Throb Youtube channel

### DIFF
--- a/diffusion-output-list
+++ b/diffusion-output-list
@@ -3,3 +3,5 @@ midjourney.com
 sigmoid.social
 reddit.com/r/aiwallpapers/
 lemmy.dbzer0.com
+www.youtube.com/@AstralThrob
+www.youtube.com/channel/UCpbH_7H71IPKq4eH7CD5spg


### PR DESCRIPTION
I'd like to 
- [x] add
- [ ] remove
these domain(s) or URL(s) to the diffusion output list.

Criteria:

- [x] This site includes diffusion output on a public-facing page.
- [x] These images hypothetically replace human artworks. (That is, they are not
  examples of diffusion output for the purpose of technical discussion.)

If either criterion are not fulfilled, your domain(s) or URL(s) cannot be on the
list.

Please describe below why these criteria are or are not fulfilled.

Although the Youtube thumbnails are attributed to an artist, they are made with generative AI which would replaces work previously done by a human.