### PR TITLE
Add lemmy.dbzer0.com

### DIFF
--- a/diffusion-output-list
+++ b/diffusion-output-list
@@ -2,3 +2,4 @@ mastodonbooks.net
 midjourney.com
 sigmoid.social
 reddit.com/r/aiwallpapers/
+lemmy.dbzer0.com


### PR DESCRIPTION
I'd like to 
- [x] add
- [ ] remove
these domain(s) or URL(s) to the diffusion output list.

Criteria:

- [x] This site includes diffusion output on a public-facing page.
- [x] These images hypothetically replace human artworks. (That is, they are not
  examples of diffusion output for the purpose of technical discussion.)

If either criterion are not fulfilled, your domain(s) or URL(s) cannot be on the
list.

Please describe below why these criteria are or are not fulfilled.

In multiple places generative AI was used for images and icons. Some can be seen on the front page in the sidebar.