### PR TITLE
timkellogg.me

### DIFF
--- a/diffusion-output-list
+++ b/diffusion-output-list
@@ -3,3 +3,4 @@ midjourney.com
 sigmoid.social
 reddit.com/r/aiwallpapers/
 lemmy.dbzer0.com
+timkellogg.me


### PR DESCRIPTION
I'd like to 
- [x] add
- [ ] remove
these domain(s) or URL(s) to the diffusion output list.

Criteria:

- [x] This site includes diffusion output on a public-facing page.
- [x] These images hypothetically replace human artworks. (That is, they are not
  examples of diffusion output for the purpose of technical discussion.)

If either criterion are not fulfilled, your domain(s) or URL(s) cannot be on the
list.

Please describe below why these criteria are or are not fulfilled.

> **Disclaimer:** All images are AI generated except for screenshots and diagrams.

— https://timkellogg.me/blog/2024/01/17/htmx