### PR TITLE
Add xeiaso.net

### DIFF
--- a/diffusion-output-list
+++ b/diffusion-output-list
@@ -8,3 +8,4 @@ sns.ourt-ai.work
 timkellogg.me
 youtube.com/@AstralThrob
 youtube.com/channel/UCpbH_7H71IPKq4eH7CD5spg
+xeiaso.net

--- a/diffusion-output-list
+++ b/diffusion-output-list
@@ -6,6 +6,6 @@ reddit.com/r/aiwallpapers/
 sigmoid.social
 sns.ourt-ai.work
 timkellogg.me
+xeiaso.net
 youtube.com/@AstralThrob
 youtube.com/channel/UCpbH_7H71IPKq4eH7CD5spg
-xeiaso.net


### PR DESCRIPTION
Resolves #6

I'd like to 
- [x] add
- [ ] remove
these domain(s) or URL(s) to the diffusion output list.

Criteria:

- [x] This site includes diffusion output on a public-facing page.
- [x] These images hypothetically replace human artworks. (That is, they are not
  examples of diffusion output for the purpose of technical discussion.)

If either criterion are not fulfilled, your domain(s) or URL(s) cannot be on the
list.

Please describe below why these criteria are or are not fulfilled.
