### PR TITLE
Add platformer.news

### DIFF
--- a/diffusion-output-list
+++ b/diffusion-output-list
@@ -2,6 +2,7 @@ chirp.social
 lemmy.dbzer0.com
 mastodonbooks.net
 midjourney.com
+www.platformer.news
 reddit.com/r/aiwallpapers/
 sigmoid.social
 sns.ourt-ai.work

--- a/diffusion-output-list
+++ b/diffusion-output-list
@@ -3,7 +3,7 @@ dougdoug.com
 lemmy.dbzer0.com
 mastodonbooks.net
 midjourney.com
-www.platformer.news
+platformer.news
 reddit.com/r/aiwallpapers/
 sigmoid.social
 sns.ourt-ai.work


### PR DESCRIPTION
I'd like to 
- [x] add
- [ ] remove
these domain(s) or URL(s) to the diffusion output list.

Criteria:

- [x] This site includes diffusion output on a public-facing page.
- [x] These images hypothetically replace human artworks. (That is, they are not
  examples of diffusion output for the purpose of technical discussion.)

If either criterion are not fulfilled, your domain(s) or URL(s) cannot be on the
list.

Please describe below why these criteria are or are not fulfilled.

The cover photo at https://www.platformer.news/why-platformer-is-leaving-substack/ is captioned as '“create a somber image displaying these characters: -30-” / DALL-E,' indicating the use of the DALL-E diffusion model.