### PR TITLE
Add a few diffusion-focused fedi instances

### DIFF
--- a/diffusion-output-list
+++ b/diffusion-output-list
@@ -1,5 +1,9 @@
+ai.wiki
+aipub.social
+boles.xyz
 chirp.social
 dougdoug.com
+genart.social
 lemmy.dbzer0.com
 mastodonbooks.net
 midjourney.com


### PR DESCRIPTION
> I'd like to 
> - [x] add
> - [ ] remove
> these domain(s) or URL(s) to the diffusion output list.
> 
> Criteria:
> 
> - [x] This site includes diffusion output on a public-facing page.
> - [x] These images hypothetically replace human artworks. (That is, they are not
>   examples of diffusion output for the purpose of technical discussion.)
> 
> If either criterion are not fulfilled, your domain(s) or URL(s) cannot be on the
> list.
> 
> Please describe below why these criteria are or are not fulfilled.

Adding some fedi instances we know about. Each of these have either admins who post diffusion art or are specifically for diffusion art.