### PR TITLE
Add toot.lgbt

### DIFF
--- a/diffusion-output-list
+++ b/diffusion-output-list
@@ -12,6 +12,7 @@ reddit.com/r/aiwallpapers/
 sigmoid.social
 sns.ourt-ai.work
 timkellogg.me
+toot.lgbt
 xeiaso.net
 youtube.com/@AstralThrob
 youtube.com/@DougDoug


### PR DESCRIPTION
I'd like to 
- [x] add
- [ ] remove
these domain(s) or URL(s) to the diffusion output list.

Criteria:

- [x] This site includes diffusion output on a public-facing page.
- [x] These images hypothetically replace human artworks. (That is, they are not
  examples of diffusion output for the purpose of technical discussion.)

If either criterion are not fulfilled, your domain(s) or URL(s) cannot be on the
list.

Please describe below why these criteria are or are not fulfilled.
Resolves #17 - Instance banner is an obvious diffusion image. It even generated a signature! 
